### PR TITLE
improve json handling, option to split sentences or not

### DIFF
--- a/doccano-elasticsearch-upload.ipynb
+++ b/doccano-elasticsearch-upload.ipynb
@@ -20,10 +20,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DOCCANO_PROJECT_ID = 8\n",
+    "DOCCANO_PROJECT_ID = 12\n",
     "CORD_UUID = '7ots8npg'\n",
     "MAX_RESULTS = 10000\n",
-    "TAG_TYPES = ['UMLS', 'GGP', 'SO', 'TAXON', 'CHEBI', 'GO', 'CL', 'DNA', 'CELL_TYPE', 'CELL_LINE', 'RNA', 'PROTEIN', 'DISEASE', 'CHEMICAL', 'CANCER', 'ORGAN', 'TISSUE', 'ORGANISM', 'CELL', 'AMINO_ACID', 'GENE_OR_GENE_PRODUCT', 'SIMPLE_CHEMICAL', 'ANATOMICAL_SYSTEM', 'IMMATERIAL_ANATOMICAL_ENTITY', 'MULTI-TISSUE_STRUCTURE', 'DEVELOPING_ANATOMICAL_STRUCTURE', 'ORGANISM_SUBDIVISION', 'CELLULAR_COMPONENT', 'PATHOLOGICAL_FORMATION', 'ORGANISM_SUBSTANCE']"
+    "TAG_TYPES = ['UMLS', 'GGP', 'SO', 'TAXON', 'CHEBI', 'GO', 'CL', 'DNA', 'CELL_TYPE', 'CELL_LINE', 'RNA', 'PROTEIN', 'DISEASE', 'CHEMICAL', 'CANCER', 'ORGAN', 'TISSUE', 'ORGANISM', 'CELL', 'AMINO_ACID', 'GENE_OR_GENE_PRODUCT', 'SIMPLE_CHEMICAL', 'ANATOMICAL_SYSTEM', 'IMMATERIAL_ANATOMICAL_ENTITY', 'MULTI-TISSUE_STRUCTURE', 'DEVELOPING_ANATOMICAL_STRUCTURE', 'ORGANISM_SUBDIVISION', 'CELLULAR_COMPONENT', 'PATHOLOGICAL_FORMATION', 'ORGANISM_SUBSTANCE']\n",
+    "SPLIT_SENTENCES = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get sentences from elasticsearch"
    ]
   },
   {
@@ -38,26 +46,66 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Label sentences\n",
+    "\n",
+    "Sentences can be joined all together or not depending on the `SPLIT_SENTENCES` option. They will be stored as one or multiple json objects in the `results` variable to be later uploaded."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "results = []\n",
-    "    \n",
+    "texts = []\n",
+    "labels = []\n",
+    "previous_length = 0\n",
+    "done_labels = [] # Some label could be applied multiple times which would cause a constraint error on doccano's side.\n",
+    "                 # This serves as marking sure a label is applied only once at a given location in the text\n",
+    "\n",
     "for hit in response['hits']['hits']:\n",
     "    sentence_id = hit['_source']['sentence_id']\n",
     "    sentence = hit['_source']['sentence']\n",
-    "    labels = []\n",
+    "    if SPLIT_SENTENCES:\n",
+    "        labels = []\n",
+    "        \n",
     "    for tag_type in TAG_TYPES:\n",
     "        tags = hit['_source'][tag_type]\n",
     "        for tag in tags:\n",
     "            if len(tag) == 1: # empty lists are returned '[]' as a string by ES, and some lists contain just punctuation symbols\n",
     "                continue\n",
+    "            \n",
     "            pos = sentence.find(tag)\n",
     "            if pos != -1:\n",
-    "                labels.append([pos, pos+len(tag), tag_type])\n",
-    "    results.append({'text':sentence, 'labels':labels})"
+    "                if not SPLIT_SENTENCES:\n",
+    "                    pos = previous_length + pos #Adding the length of previous sentences to calculate the new position\n",
+    "                \n",
+    "                if '{},{},{}'.format(pos, pos+len(tag), tag_type) not in done_labels:\n",
+    "                    labels.append([pos, pos+len(tag), tag_type])\n",
+    "                    done_labels.append('{},{},{}'.format(pos, pos+len(tag), tag_type))\n",
+    "    \n",
+    "    if SPLIT_SENTENCES:\n",
+    "        results.append(json.dumps({\"text\":sentence, \"labels\":labels}))\n",
+    "    else:\n",
+    "        if sentence[-1] == '.':\n",
+    "            sentence = sentence[:-1]\n",
+    "        \n",
+    "        previous_length += len(sentence) + 2 # Sentences will be joined with '. '\n",
+    "        texts.append(sentence)\n",
+    "\n",
+    "if not SPLIT_SENTENCES: \n",
+    "    results = [json.dumps({\"text\":'. '.join(texts), \"labels\":labels})]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Doccano connection and file upload"
    ]
   },
   {
@@ -76,30 +124,23 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "for result in results:\n",
-    "    with tempfile.NamedTemporaryFile(suffix='.json') as tmp:\n",
-    "        parts = tmp.name.split('/')\n",
-    "        filename = parts[-1]\n",
-    "        directory = '/'.join(parts[:-1])\n",
-    "        tmp.write((str(result)).replace(\"'\",'\"').encode('UTF-8'))\n",
-    "        tmp.seek(0)\n",
-    "        time.sleep(.1)\n",
-    "        response_upload = doccano_client.post_doc_upload(DOCCANO_PROJECT_ID, 'json', filename, directory)\n",
-    "        if response_upload.status_code >= 400:\n",
-    "            print('Error {}:{}'.format(response_upload.status_code, response_upload.text))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "with tempfile.NamedTemporaryFile(suffix='.json') as tmp:\n",
+    "    parts = tmp.name.split('/')\n",
+    "    filename = parts[-1]\n",
+    "    directory = '/'.join(parts[:-1])\n",
+    "    \n",
+    "    for i, result in enumerate(results):\n",
+    "        tmp.write(result.encode('UTF-8'))\n",
+    "    tmp.seek(0)\n",
+    "    response_upload = doccano_client.post_doc_upload(DOCCANO_PROJECT_ID, 'json', filename, directory)\n",
+    "    \n",
+    "    if response_upload.status_code >= 400:\n",
+    "        print('Error {}:{}'.format(response_upload.status_code, response_upload.text))\n",
+    "print(\"Done {} texts\\n\".format(i+1))"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
Turns out I wasn't using the `json.dumps()` when I should have, thus causing multiple problems with quotes.
This PR also adds the possibility to upload a whole text or sentences separately.